### PR TITLE
Allow dockerfile filename overrides

### DIFF
--- a/src/jobs/docker/nexus.yml
+++ b/src/jobs/docker/nexus.yml
@@ -31,8 +31,8 @@ parameters:
     default: ''
     type: string
   path:
-    description: Directory path containing a Dockerfile.
-    default: .
+    description: Path to a particular Dockerfile or containing directory with a Dockerfile present.
+    default: Dockerfile
     type: string
   username:
     description: Docker username.
@@ -55,8 +55,15 @@ steps:
   - run:
       name: Build and push tag
       command: |+
-        docker build . -f << parameters.path >>/Dockerfile -t << parameters.nexus-domain >>/<< parameters.image-name >>:<< parameters.tag >> << parameters.args >>
-        docker push << parameters.nexus-domain >>/<< parameters.image-name >>:<< parameters.tag >>
+        if [ "$(echo "<< parameters.path >>" | grep -oP "Dockerfile")" != "Dockerfile" ]; then
+            # Path does not contain the dockerfile, so we default to "Dockerfile".
+            docker build . -f ./<< parameters.path >>/Dockerfile -t << parameters.nexus-domain >>/<< parameters.image-name >>:<< parameters.tag >> << parameters.args >>
+            docker push << parameters.nexus-domain >>/<< parameters.image-name >>:<< parameters.tag >>
+        else
+            # Path does specify the Dockerfile explictly, don't default to "Dockerfile". E.g., "docker/Dockerfile.develop".
+            docker build . -f ./<< parameters.path >> -t << parameters.nexus-domain >>/<< parameters.image-name >>:<< parameters.tag >> << parameters.args >>
+            docker push << parameters.nexus-domain >>/<< parameters.image-name >>:<< parameters.tag >>
+        fi
   - when:
       condition: << parameters.commit-tag >>
       steps:


### PR DESCRIPTION
Allows us to specify a `path: some/dir/Dockerfile.develop`, e.g., if we want to specify a particular Dockerfile to build. Allows me to handle multiple environments & branches, e.g. `Dockerfile.develop`, `Dockerfile.master`, etc.