### PR TITLE
Fix image tag value update

### DIFF
--- a/src/jobs/helm/release/nexus.yml
+++ b/src/jobs/helm/release/nexus.yml
@@ -55,7 +55,7 @@ steps:
         - run:
             name: Update image tag
             command: |
-              yq -i '<< parameters.image-tag-path >> = "<< parameters.image-tag >>"' << parameters.path >>/values.yaml
+              yq -i "<< parameters.image-tag-path >> = \"<< parameters.image-tag >>\"" << parameters.path >>/values.yaml
   - run:
       name: 'nexus-helm: package'
       command: |+


### PR DESCRIPTION
Single quotes won't expand env vars (e.g. $CIRCLE_TAG).